### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# traits.build-book — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add traits.build-book-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`traits.build-book` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
+  rules, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: traits.build-book-specific architecture, key entry points, build & test, known gotchas._

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# traits.build-book — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add traits.build-book-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`traits.build-book` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
-  rules, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: traits.build-book-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# traits.build-book — agent & contributor guide
+
+`traits.build-book` is the **`traits.build` user manual** — a Quarto book covering the
+traits.build data standard, R package, and workflow, with best-practice advice and tutorials.
+The rendered manual lives at <https://traitecoevo.github.io/traits.build-book/>.
+
+## Repo-local guidance
+
+- **Type:** a [Quarto book](https://quarto.org/docs/books/) project, **not** an R package
+  (the top-level `DESCRIPTION`/`NAMESPACE` exist only to declare the R packages the chapters
+  need at render time).
+- **Layout:** a single `_quarto.yml` at the top level defines the book (title, parts, chapter
+  order, HTML format), and each chapter is one `.qmd` source file. `_metadata.yml` holds shared
+  chapter options; `references.bib` is the bibliography; `figures/` and `data/` hold supporting
+  assets; `_book/` and `_freeze/` are generated output/cache.
+- **Chapters:** organised in `_quarto.yml` into parts — Introduction (`index.qmd`,
+  `motivation.qmd`, `workflow.qmd`, ...), Data structure & standard, Creating with
+  `traits.build`, a step-by-step Guide to adding data (`tutorial_dataset_1..7.qmd`), Using
+  outputs, and Getting help; appendices `csv.qmd`, `yaml.qmd`.
+- **Build / preview:** `quarto render` builds the book into `_book/`; `quarto preview` serves it
+  with live reload. Rendering executes the `.qmd` code, so the R packages in `DESCRIPTION`
+  (incl. `traits.build`, `austraits`, `APCalign`, tidyverse, `galah`, `sf`) must be installed.
+- **Publishing:** a `render` GitHub Actions workflow builds the book (see the README badge); the
+  rendered site is served from the `gh-pages` branch.
+- **Default branch:** `master`.
+
+> Heads-up: the PDF `format` in `_quarto.yml` is commented out — the book is HTML-only as
+> configured. Don't assume `quarto render --to pdf` works without re-enabling that block.
+
+---
+
+## AusTraits family — cross-package context
+
+`traits.build-book` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the traits.build user manual / book.
+Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, source-of-truth rules, cross-boundary
+  artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ This repository is the [`traits.build`](https://github.com/traitecoevo/traits.bu
 
 The manual is implemented as a typical [`quarto book`](https://quarto.org/docs/books/) project with a single `_quarto.yml` file at the top level and one Quarto source file for each chapter. End users are encouraged to read the rendered output at <https://traitecoevo.github.io/traits.build-book/>.
 
+## AusTraits family
+
+`traits.build-book` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.
+
 ## Code of conduct
 
 Please note that the `traits.build` project adheres to a [Contributor Code of Conduct, as specified in austraits.build](https://github.com/traitecoevo/austraits.build/blob/develop/.github/CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- README — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)