### PR TITLE
docs: fix broken links, citations, acknowledgement & stale content

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Please note that the `traits.build` project adheres to a [Contributor Code of Co
 
 ## Acknowledgements
 
-This manual arose from code within the AusTraits project at <https://github.com/traitecoevo/austraits.build>. The AusTraits project received investment (<https://doi.org/10.47486/DP720>) from the Australian Research Data Commons (ARDC). The ARDC is funded by the National Collaborative Research Infrastructure Strategy (NCRIS).
+This manual arose from code within the AusTraits project at <https://github.com/traitecoevo/austraits.build>. AusTraits is a co-investment partnership with the [Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris) (NCRIS). This work received investment ([DP720](https://doi.org/10.47486/DP720)) from the ARDC.

--- a/adding_data_long.qmd
+++ b/adding_data_long.qmd
@@ -35,10 +35,9 @@ Then come back to this document for details and unusual dataset circumstances th
 
 Other chapters you may want to read include:
 
--   an [overview of `traits.build`](overview.html),
--   the instructions provided to [data contributors](contributing_data.html),
+-   an [overview of `traits.build`](traits_build.html),
 -   the [structure of a compiled `traits.build` database](database_structure.html),
--   the [structure of the raw data files](file_structure.html)
+-   the [structure of the raw data files](file_organisation.html)
 -   the [overview for adding data](adding_data_brief.html).
 
 ## Getting started

--- a/austraits_database.qmd
+++ b/austraits_database.qmd
@@ -1,10 +1,10 @@
 # AusTraits, Australia's Plant Trait Database
 
-[AusTraits](https://github.com/traitecoevo/austraits.build), Australia's largest plant trait database was the first trait database to be build using the traits.build workflow.
+[AusTraits](https://github.com/traitecoevo/austraits.build), Australia's largest plant trait database, was the first trait database to be built using the traits.build workflow.
 
 ## AusTraits data records
 
-As of October, 2023, AusTraits has:
+AusTraits includes (see the [latest release on Zenodo](https://doi.org/10.5281/zenodo.3568417) for current totals):
 
 -   370+ datasets 
 

--- a/help.qmd
+++ b/help.qmd
@@ -2,10 +2,6 @@
 
 This chapter explains how to ask for help. Questions can range from [detailed troubleshooting](data_common_issues.html) to [general advice](#general_advice). To ensure a constructive dialogue, please read this entire page before reaching out. Thank you for respecting the time and effort it takes to provide one-on-one support.
 
-Links to 
-
-- [troubleshooting](troubleshooting.html)
-
 :::{.callout-note}
 
 ## Summary {#general_advice}
@@ -70,8 +66,8 @@ There are many ways to reach out.
 
 To contact the maintainer directly, please post to the relevant public [GitHub Discussions](https://github.com/features/discussions) page of the package.^[You may need to create a free [GitHub](https://github.com/) account, but the process is straightforward.] Examples:
 
-* `traits.build`: <https://github.com/ropensci/targets/discussions>
-* `austraits`: <https://github.com/ropensci/tarchetypes/discussions>
+* `traits.build`: <https://github.com/traitecoevo/traits.build/discussions>
+* `austraits`: <https://github.com/traitecoevo/austraits/discussions>
 
 
 GitHub makes it easy to search for and link to public discussions. Not only does this help users solve their own problems, it also helps the maintainer avoid repetition. So please use discussions instead of private emails, instant messages, or mentions on social media.

--- a/index.qmd
+++ b/index.qmd
@@ -4,9 +4,15 @@
 
 Imagine you wanted to build a database of traits. You might start by compiling data from existing datasets, but you'd quickly find that there are many different ways to name and measure the same trait, that different studies use different units, or use an outdated name for a species or taxon.
 
-`traits.build` is a data standard, R package, and workflow that is desgined to help you build a harmonised, relational database from disparate datasets. The package was first developed to create  [`austraits.build`](https://github.com/traitecoevo/austraits.build/) an, open-source database of Australian plant traits. The code has been transformed into a standalone package allowing anyone to build a relational, tabular database for any taxonomic group and any collection of traits.
+`traits.build` is a data standard, R package, and workflow that is designed to help you build a harmonised, relational database from disparate datasets. The package was first developed to create [`austraits.build`](https://github.com/traitecoevo/austraits.build/), an open-source database of Australian plant traits. The code has been transformed into a standalone package allowing anyone to build a relational, tabular database for any taxonomic group and any collection of traits.
 
-A description of this package is available at: Wenk, E., Bal, P., Coleman, D., Gallagher, R., Yang, S., Falster, D., 2024. Traits.build: A data model, workflow and R package for building harmonised ecological trait databases. Ecological Informatics 83, 102773. [DOI: j.ecoinf.2024.102773](https://doi.org/10.1016/j.ecoinf.2024.102773)
+## How to cite
+
+If you use `traits.build`, please cite:
+
+> Wenk, E., Bal, P., Coleman, D., Gallagher, R., Yang, S., Falster, D. (2024) traits.build: A data model, workflow and R package for building harmonised ecological trait databases. *Ecological Informatics* 83, 102773. <https://doi.org/10.1016/j.ecoinf.2024.102773>
+
+If you use the **AusTraits** dataset, also cite Falster et al. (2021) *Scientific Data* 8:254 (<https://doi.org/10.1038/s41597-021-01006-6>); for the **AusTraits Plant Dictionary** cite Wenk et al. (2024) *Scientific Data* 11:537 (<https://doi.org/10.1038/s41597-024-03368-z>); and for **APCalign** cite Wenk et al. (2024) *Australian Journal of Botany* 72:BT24014 (<https://doi.org/10.1071/BT24014>).
 
 
 ## About this manual
@@ -21,13 +27,13 @@ This manual is a step-by-step user guide to the `traits.build` standard, R packa
 
 To get you started, we've provided a template example compilation which you can clone and modify. This provides the basic steps for building a `traits.build` compilation. Follow the instructions in [Tutorials](tutorial_compilation.html) chapter for a step-by-step guide to building a database from scratch.
 
-<!-- XXX Video? -->
-
 ## Getting help
 
 Along the way, users may encounter a number of errors and warnings. Some of these are designed to help you build a robust database, others may constitue an error in your data, file structure, or the package. If you encounter an error or warning, please read the message carefully and [follow the instructions for getting help](help.html). 
 
 ## Acknowledgements
 
-This manual arose from code within the AusTraits project at <https://github.com/traitecoevo/austraits.build>. The AusTraits project received investment (<https://doi.org/10.47486/DP720>) from the Australian Research Data Commons (ARDC). The ARDC is funded by the National Collaborative Research Infrastructure Strategy (NCRIS).
+This manual arose from code within the AusTraits project at <https://github.com/traitecoevo/austraits.build>.
+
+AusTraits is a co-investment partnership with the [Australian Research Data Commons](https://ardc.edu.au/) (ARDC) through the Planet Research Data Commons ([DOI: 10.3565/nyk4-4r91](https://doi.org/10.3565/nyk4-4r91)). The ARDC is enabled by the Australian Government's [National Collaborative Research Infrastructure Strategy](https://www.education.gov.au/ncris) (NCRIS). This work received investment ([DP720](https://doi.org/10.47486/DP720)) from the ARDC.
 

--- a/motivation.qmd
+++ b/motivation.qmd
@@ -21,7 +21,7 @@ We developed these tools for the to create  [AusTraits](https://github.com/trait
 Along the way, we hdeveloped a suite of tools:
 
 - [traits.build data standard](database_standard.html): a relational database structure that fully documents the contextual data essential to interpreting ecological data.
-- [traits.build R package](traits.build.html): a set of functions that enable users to create a harmonised database from disparate datasets.
+- [traits.build R package](traits_build.html): a set of functions that enable users to create a harmonised database from disparate datasets.
 - [APD](http://w3id.org/APD/): The AusTraits Plant Dictionary, with  detailed descriptions for more than 500 plant trait concepts.  
 - [APCalign](https://github.com/traitecoevo/APCalign): an R package to align and update Australian plant taxon name strings with the Australian Plant Census.
 

--- a/references.bib
+++ b/references.bib
@@ -1,19 +1,54 @@
-@article{knuth84,
-  author = {Knuth, Donald E.},
-  title = {Literate Programming},
-  year = {1984},
-  issue_date = {May 1984},
-  publisher = {Oxford University Press, Inc.},
-  address = {USA},
-  volume = {27},
-  number = {2},
-  issn = {0010-4620},
-  url = {https://doi.org/10.1093/comjnl/27.2.97},
-  doi = {10.1093/comjnl/27.2.97},
-  journal = {Comput. J.},
-  month = may,
-  pages = {97–111},
-  numpages = {15}
+% AusTraits family — key papers (see traitecoevo/austraits-meta/references)
+
+@article{Falster-2021a,
+  title   = {AusTraits, a curated plant trait database for the Australian flora},
+  author  = {Falster, Daniel and Gallagher, Rachael and Wenk, Elizabeth H. and Wright, Ian J. and Indiarto, Dony and Andrew, Samuel C. and others},
+  year    = {2021},
+  journal = {Scientific Data},
+  volume  = {8},
+  number  = {1},
+  pages   = {254},
+  doi     = {10.1038/s41597-021-01006-6}
 }
 
+@article{Wenk-2024b,
+  title   = {traits.build: A data model, workflow and R package for building harmonised ecological trait databases},
+  author  = {Wenk, Elizabeth and Bal, Payal and Coleman, David and Gallagher, Rachael and Yang, Sophie and Falster, Daniel S.},
+  year    = {2024},
+  journal = {Ecological Informatics},
+  volume  = {83},
+  pages   = {102773},
+  doi     = {10.1016/j.ecoinf.2024.102773}
+}
 
+@article{Wenk-2024a,
+  title   = {The AusTraits Plant Dictionary},
+  author  = {Wenk, Elizabeth H. and Sauquet, Herv{\'e} and Gallagher, Rachael V. and Falster, Daniel S. and others},
+  year    = {2024},
+  journal = {Scientific Data},
+  volume  = {11},
+  number  = {1},
+  pages   = {537},
+  doi     = {10.1038/s41597-024-03368-z}
+}
+
+@article{Wenk-2024c,
+  title   = {APCalign: An R package workflow and app for aligning and updating flora names to the Australian Plant Census},
+  author  = {Wenk, Elizabeth H. and Cornwell, William K. and Fuchs, Anne and Kar, Fonti and Monro, Anna M. and Sauquet, Herv{\'e} and Stephens, Ruby E. and Falster, Daniel S.},
+  year    = {2024},
+  journal = {Australian Journal of Botany},
+  volume  = {72},
+  number  = {4},
+  pages   = {BT24014},
+  doi     = {10.1071/BT24014}
+}
+
+@article{Coleman-2023,
+  title   = {A workflow to create trait databases from collections of textual taxonomic descriptions},
+  author  = {Coleman, David and Gallagher, Rachael V. and Falster, Daniel S. and Sauquet, Herve and Wenk, Elizabeth},
+  year    = {2023},
+  journal = {Ecological Informatics},
+  volume  = {78},
+  pages   = {102312},
+  doi     = {10.1016/j.ecoinf.2023.102312}
+}

--- a/traits_build.qmd
+++ b/traits_build.qmd
@@ -1,15 +1,15 @@
 # The package
 
-The traits.build package provides a workflow for harmonising data from disconnected primary sources and arises from the [AusTraits project](austraits.org). In 2023 this package was spun out as a separate package from the autraits.build repository.
+The traits.build package provides a workflow for harmonising data from disconnected primary sources and arises from the [AusTraits project](https://austraits.org). In 2023 this package was spun out as a separate package from the austraits.build repository.
 
-The `traits.build` package provides the functions needed to build a compilation from the primary sources ino a standardised database. specified 
+The `traits.build` package provides the functions needed to build a compilation from the primary sources into a standardised database.
 
 The core components of the `{traits.build}` package are:  
 
-1.  15 functions functions, supplemented by a detailed [protocol](tutorial_datasets.html) to wrangle diverse datasets into input files with a common structure that captures both the trait data and all essential metadata and context properties. These are a table (data.csv) containing all trait data, taxon names, location names (if relevant), and any context properties (if relevant) and a structured metadata file (metadata.yml) that assigns the columns from the `data.csv` file to their specific variables and maps all additional dataset metadata in a structured format. 
+1.  15 functions, supplemented by a detailed [protocol](tutorial_datasets.html) to wrangle diverse datasets into input files with a common structure that captures both the trait data and all essential metadata and context properties. These are a table (data.csv) containing all trait data, taxon names, location names (if relevant), and any context properties (if relevant) and a structured metadata file (metadata.yml) that assigns the columns from the `data.csv` file to their specific variables and maps all additional dataset metadata in a structured format. 
 
 2.  An R-based pipeline to combine the input files into a single harmonised database with aligned trait names, aligned units, aligned categorical trait values, and aligned taxon names. Four database-specific configuration files are required for the build process, 1) a trait dictionary; 2) a units conversion file; 3) a taxon list; and 4) a database metadata file. 
 
 Guided by the information in the configuration files, the R-scripted workflow combines the `data.csv` and `metadata.yml` files for the individual datasets into a unified, harmonised database. There are three distinct steps to this process, processed by a trio of functions, `dataset_configure`, `dataset_process`, and `dataset_taxonomic_updates`. These functions cyclically build each dataset, only combining them into a single database at the end of the workflow.
 
-A combination of automated [tests](adding_data_long#running_tests.html) and other [quality controls](adding_data_long#running_tests.html#quality_checks) ensure each dataset has been appropriately merged in and the output data are reliable, accurate, and supported by detailed metadata.  
+A combination of automated [tests](adding_data_long.html) and other [quality controls](check_dataset_functions.html) ensure each dataset has been appropriately merged in and the output data are reliable, accurate, and supported by detailed metadata.  

--- a/tutorial_compilation.qmd
+++ b/tutorial_compilation.qmd
@@ -25,9 +25,9 @@ This tutorial walks you through an example of creating a `traits.build` database
 
     -   By working through the dataset tutorials, you are progressively introduced to how the complexities of ecological datasets can be documented within the `traits.build` structure
 
-    -   The datasets offer explicit examples of the types of complexities summarised in the [Adding Data](https://github…) vignette.
+    -   The datasets offer explicit examples of the types of complexities summarised in the [Adding datasets, a lengthy guide](adding_data_long.html) chapter.
 
-    -   As of September 2023 there are 3 tutorials, but this will expand to 6 tutorials by October 2023.
+    -   There are seven dataset tutorials, progressing from simple to more complex dataset structures.
 
 To clone the repository, either visit the GitHub repository and click on the green `<> Code` tab toward the upper right corner of the [landing page](https://github.com/traitecoevo/traits.build-template), or clone the repository through GitHub desktop, R Studio, or your choice of Git client. 
 


### PR DESCRIPTION
First pass of the traits.build book usability work (part of `traitecoevo/austraits-meta` → `plans/family-usability-overhaul.md`).

**Broken/wrong cross-references**
- `help.qmd`: maintainer contact links pointed at `ropensci/targets` and `ropensci/tarchetypes` (leftovers from adapting the targets book) → now `traitecoevo/traits.build` and `traitecoevo/austraits`; removed a leftover `troubleshooting.html` stub.
- `adding_data_long.qmd`: `overview.html` / `contributing_data.html` / `file_structure.html` → real chapters (`traits_build.html`, `file_organisation.html`).
- `motivation.qmd`: `traits.build.html` → `traits_build.html`.
- `traits_build.qmd`: fixed malformed `adding_data_long#running_tests.html` anchors and the `(austraits.org)` link.
- `tutorial_compilation.qmd`: fixed the truncated `[Adding Data](https://github…)` placeholder link.

**Citations**
- Added a **How to cite** section to `index.qmd` (traits.build + AusTraits / APD / APCalign).
- Replaced the vestigial `references.bib` (only `knuth84`) with the family citation set.

**De-stale**
- Dropped the "as of October 2023" stats framing and the "3 tutorials … by October 2023" promise (there are seven); fixed assorted typos on the intro pages.

**Acknowledgement**
- NCRIS "enabled by" + Planet RDC framing in `index.qmd` and `README.md` (was "funded by").

Deliberately avoids the files/typos in open **PR #25** (which is based on an older master). Renders locally (`quarto render` of the edited prose chapters).

### Still to come (larger content work)
New chapters (quick-start/install, troubleshooting, glossary, an actionable publishing chapter), merging the duplicated file-structure chapter, and de-duplicating the austraits-package/tutorial overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)