### PR TITLE
Point AGENTS.md at the commit-message convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,5 +51,11 @@ the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob
 pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
 labels.
 
+**Commit messages:** every family repo squash-merges, so the **PR title and body become the permanent
+commit message**. Keep the subject ≤50 characters as typed and the body ≤10 lines; put the working
+detail — what you tried, benchmarks, test counts, rejected alternatives — in the **first PR comment**
+instead. Full convention:
+[`commit-messages.md`](https://github.com/traitecoevo/austraits-meta/blob/master/governance/commit-messages.md).
+
 > austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
 > actual repos.


### PR DESCRIPTION
Every family repo squash-merges, so a PR's title and body become the
permanent commit message, appended with ` (#NNN)`. Nothing in this repo
said so, and the working detail people put in descriptions was landing
in permanent history.

Adds a "Commit messages" bullet to the cross-package block in
`AGENTS.md`. Pointer only: the convention itself stays in
austraits-meta, so the ten repos that reference it cannot drift into
divergent local copies.
